### PR TITLE
Render "wrapEnd" template missing modeules parts, because options use a ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ exports.packAsAll = function () {
         return mod.name.indexOf('chart/map') >= 0;
     }).length > 0;
     var wrapEnd = etpl.compile(wrapEndTpl)({
-        parts: module.parts,
+        parts: modules.parts,
         hasMap: hasMap
     });
     var code = wrapStart + wrapNut + result + wrapEnd;


### PR DESCRIPTION
Render "wrapEnd" template missing modeules parts, because options use a wrong variable "module.parts", it should be "module.parts".